### PR TITLE
fix: Do not attempt to recursively load configuration

### DIFF
--- a/fixtures/nyc.config.js
+++ b/fixtures/nyc.config.js
@@ -1,0 +1,5 @@
+import loader from '@istanbuljs/load-nyc-config';
+
+export default {
+	include: loader.isLoading() ? ['hooked.js'] : []
+};

--- a/fixtures/package.json
+++ b/fixtures/package.json
@@ -1,0 +1,6 @@
+{
+	"type": "module",
+	"peerDependencies": {
+		"@istanbuljs/load-nyc-config": "*"
+	}
+}

--- a/index.js
+++ b/index.js
@@ -8,20 +8,24 @@ function nycEnvironmentConfig() {
 	try {
 		return JSON.parse(process.env.NYC_CONFIG);
 	} catch {
-		return null;
 	}
 }
 
-const initialCWD = process.env.NYC_CWD || process.cwd();
-let nycConfig = nycEnvironmentConfig();
+let nycConfig;
 let testExclude;
 let babelConfig;
 
 export async function transformSource(source, context) {
-	if (nycConfig === null) {
-		nycConfig = {
+	if (loader.isLoading()) {
+		return {source};
+	}
+
+	if (!nycConfig) {
+		nycConfig = nycEnvironmentConfig() || {
 			...schema.defaults.nyc,
-			...await loader.loadNycConfig({cwd: initialCWD})
+			...await loader.loadNycConfig({
+				cwd: process.env.NYC_CWD || process.cwd()
+			})
 		};
 	}
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"homepage": "https://github.com/istanbuljs/esm-loader-hook#readme",
 	"dependencies": {
 		"@babel/core": "^7.8.7",
-		"@istanbuljs/load-nyc-config": "^1.0.0",
+		"@istanbuljs/load-nyc-config": "^1.1.0",
 		"@istanbuljs/schema": "^0.1.2",
 		"babel-plugin-istanbul": "^6.0.0",
 		"test-exclude": "^6.0.0"

--- a/test/index.js
+++ b/test/index.js
@@ -36,13 +36,32 @@ test('transform hook', async t => {
 		{
 			env: {
 				...process.env,
+				NYC_CWD: fileURLToPath(new URL('../fixtures', import.meta.url).href),
 				NODE_OPTIONS: [].concat(
 					process.env.NODE_OPTIONS || [],
 					'--experimental-loader @istanbuljs/esm-loader-hook'
 				).join(' ')
 			}
 		},
-		'transform1.js'
+		'transform-hook.js'
+	);
+});
+
+test('load config with transform hook', async t => {
+	await t.spawn(
+		process.execPath,
+		[fileURLToPath(new URL('transform-hook-load-config.js', import.meta.url).href)],
+		{
+			cwd: fileURLToPath(new URL('../fixtures', import.meta.url).href),
+			env: {
+				...process.env,
+				NODE_OPTIONS: [].concat(
+					process.env.NODE_OPTIONS || [],
+					`--experimental-loader ${new URL('../index.js', import.meta.url).href}`
+				).join(' ')
+			}
+		},
+		'transform-hook-load-config.js'
 	);
 });
 

--- a/test/transform-hook-load-config.js
+++ b/test/transform-hook-load-config.js
@@ -1,0 +1,18 @@
+import {fileURLToPath} from 'url';
+
+import t from 'libtap';
+import loader from '@istanbuljs/load-nyc-config';
+
+t.test('load config', async t => {
+	const config = await loader.loadNycConfig();
+
+	t.same(config.include, ['hooked.js']);
+
+	await import('../fixtures/hooked.js');
+
+	const transformFile = fileURLToPath(new URL('../fixtures/hooked.js', import.meta.url).href);
+
+	t.equal(Object.keys(global.__coverage__).length, 1);
+	const transformCoverage = global.__coverage__[transformFile];
+	t.equal(transformCoverage.path, transformFile);
+});


### PR DESCRIPTION
If this transform hook is set for the main nyc process the configuration
load causes this hook to run.  This resulted in process failure.

Return original source when `@istanbuljs/load-nyc-config` is loading a
configuration file.