### PR TITLE
ci: run tests on latest node v18 and v20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [16]
+        node-version: [16, 18, 20]
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Execute tests also for node v18 and v20 to ensure functionality also in later node versions