### PR TITLE
Added typescript & decorators support

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ export async function load(url, context, nextLoad) {
 
 	/* Can/should this handle inputSourceMap? */
 	const {code} = await babel.transformAsync(source, {
-		presets: ["@babel/preset-typescript"],
+		presets: ['@babel/preset-typescript'],
 		babelrc: false,
 		configFile: false,
 		filename,
@@ -69,7 +69,7 @@ export async function load(url, context, nextLoad) {
 		},
 		plugins: [
 			['babel-plugin-istanbul', babelConfig],
-			["@babel/plugin-syntax-decorators", { decoratorsBeforeExport: true }]
+			['@babel/plugin-syntax-decorators', {decoratorsBeforeExport: true}]
 		]
 	});
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ export async function load(url, context, nextLoad) {
 
 	/* Can/should this handle inputSourceMap? */
 	const {code} = await babel.transformAsync(source, {
+		presets: ["@babel/preset-typescript"],
 		babelrc: false,
 		configFile: false,
 		filename,
@@ -67,7 +68,8 @@ export async function load(url, context, nextLoad) {
 			plugins: babelConfig.parserPlugins
 		},
 		plugins: [
-			['babel-plugin-istanbul', babelConfig]
+			['babel-plugin-istanbul', babelConfig],
+			["@babel/plugin-syntax-decorators", { decoratorsBeforeExport: true }]
 		]
 	});
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
 	},
 	"homepage": "https://github.com/istanbuljs/esm-loader-hook#readme",
 	"dependencies": {
+		"@babel/plugin-syntax-decorators": "^7.25.9",
+		"@babel/preset-typescript": "^7.26.0",
 		"@babel/core": "^7.8.7",
 		"@istanbuljs/load-nyc-config": "^1.1.0",
 		"@istanbuljs/schema": "^0.1.3",


### PR DESCRIPTION
I tested the hook in a Typescript project, using Typescript 5.7 (w/`tsx`), Mocha v.10, Sinon v.17, and most important Chai v.5. Many old CommonJS projects are barred from moving to Chai v.5 if they use `nyc` for coverage, because Chai v.5 is ESM only. For me moving to `c8` is a no-no, because there are cases in which the coverage is not as accurate as istanbul/nyc (tbh I don't remember the exact scenarios, I tested it a while ago).

My working configuration is as follows.

- `"type" : "module"` in package.json
- Mocha config in package.json:
  - ```Javascript
    "mocha": {
      "require": [
        "./test/register-loader.js",  // this would just register `esm-loader-hook`, see my snippet below.
        "tsx"
      ],
      "color": true,
      "full-trace": true,
      "bail": true,
      "spec": [
        "test/**/*.test.ts"
      ],
      "enable-source-maps": true
    }
    ```
- nyc config in package.json:
  - ```Javascript
    "nyc": {
      "include": [
        "src/**/*.ts"
      ],
      "reporter": [
        "text-summary",
        "lcov"
      ],
      "sourceMap": true,
      "instrument": true,
      "check-coverage": true,
      "lines": 100,
      "statements": 100,
      "functions": 100,
      "branches": 100
    }
    ```
- ./test/register-loader.js
  - ```Javascript
    import { register } from "node:module"; 
    import { pathToFileURL } from "node:url"; 
    register("./test/esm-loader-hook-edited.js", pathToFileURL("./"));  // this should point to the library once this PR is merged
    ```
- added  `"allowSyntheticDefaultImports": true,` in tsconfig.json for babel compatibility


With the above, just running `npx nyc mocha` gives me the correct coverage output, and works with decorators as well.