### PR TITLE
ci: Update github actions 'checkout' and 'setup-node' to latest v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
         node-version: [16, 18, 20]
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Node.js ${{matrix.node-version}} on ${{matrix.os}}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.node-version}}
     - run: npm install


### PR DESCRIPTION
- https://github.com/actions/checkout/releases/tag/v4
- https://github.com/actions/setup-node/releases/tag/v4