### PR TITLE
ci: run tests on latest node v23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [16, 18, 20, 22]
+        node-version: [16, 18, 20, 22, 23]
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Execute tests also for node v23 to ensure functionality in latest node version